### PR TITLE
Corrige script de Normalização de env para OSX

### DIFF
--- a/bin/env-normalize.ksh
+++ b/bin/env-normalize.ksh
@@ -1,0 +1,23 @@
+#!/usr/bin/env ksh
+typeset -A collection;
+envFile=${1:-.env}
+envTarget=var/cache/.env;
+test -d var/cache || mkdir -p var/cache;
+while IFS='=' read -r key temp || [ -n "$key" ]; do
+isComment='^[[:space:]]*#'
+isBlank='^[[:space:]]*$'
+[[ $key =~ $isComment ]] && continue
+[[ $key =~ $isBlank ]] && continue
+collection[$key]=$temp;
+done < $envFile
+
+printf "##### COMPILED ENV #####\n" > $envTarget;
+for K in "${!collection[@]}"; do 
+    grep "$K=" $envFile | grep -v "^#" | tail -n 1 >> $envTarget;
+done
+
+# Ordena alfabeticamente as variaveis e elimina variaveis vazias
+sort $envTarget | uniq -u > $envFile;
+
+## Garante traefik config
+test -f config/traefik.toml || cp -v config/traefik-example.toml config/traefik.toml && echo ".";

--- a/bin/make-file/targets/01-control.mk
+++ b/bin/make-file/targets/01-control.mk
@@ -25,7 +25,11 @@ start: boot@basic stages@up
 dotenv@start:
 	test -f .env.local || printf "\n#env local\n" > .env.local
 	cat ./.env.default ./.env.local > ./.env;
+ifeq ($(shell uname) , Linux)
 	./bin/env-normalize.sh ./.env;
+else
+	printf "${COLOR_COMMENT}$(shell uname) OS. ${COLOR_INFO}No normalization performed!${COLOR_RESET}\n";
+endif
 	printf "${COLOR_COMMENT}Env Defined.${COLOR_RESET}\n"
 
 stages@up:

--- a/bin/make-file/targets/01-control.mk
+++ b/bin/make-file/targets/01-control.mk
@@ -25,10 +25,10 @@ start: boot@basic stages@up
 dotenv@start:
 	test -f .env.local || printf "\n#env local\n" > .env.local
 	cat ./.env.default ./.env.local > ./.env;
-ifeq ($(shell uname) , Linux)
+ifneq ($(shell uname), Darwin)
 	./bin/env-normalize.sh ./.env;
 else
-	printf "${COLOR_COMMENT}$(shell uname) OS. ${COLOR_INFO}No normalization performed!${COLOR_RESET}\n";
+	./bin/env-normalize.ksh ./.env;
 endif
 	printf "${COLOR_COMMENT}Env Defined.${COLOR_RESET}\n"
 


### PR DESCRIPTION
Foi adicionado ao make checagem do tipo do sistema operacional. Caso seja OSX executa script ksh ao invés de bash, já que a versão usada de bash pelo OSX não suporta arrays associativos.