### PR TITLE
correção para inicio automatico do traefik durante logon, 

### DIFF
--- a/bin/ssl-traefik-normalize.sh
+++ b/bin/ssl-traefik-normalize.sh
@@ -7,7 +7,9 @@ symlinks_default_cert_to_dot_place() {
     local source_file=/etc/nginx/certs/${SERVER_DEFAULT_HOST}.${file_prefix};
     local target_file=/etc/nginx/certs/.place.${file_prefix};
     printf "Symlink %s => %s\n" "${source_file}" "${target_file}";
-    docker-compose exec nginx-proxy bash -c "test -h ${target_file} && echo -n . || ln -sn ${source_file} ${target_file} ";
+    docker-compose exec nginx-proxy bash -i -c "test -h ${target_file} && echo -n . || ln -sn ${source_file} ${target_file}";
+    printf "Symlink %s => %s\n" "${source_file}" "${target_file}";
+
 }
 
 symlinks_default_cert_to_dot_place "crt";


### PR DESCRIPTION
Adicionado parametro -i no docker-compose e tambem adiciona um printf ao final da linha. Pois problema persistia se o docker-compose estivesse no final.